### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,9 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/redis-tester/security/code-scanning/2](https://github.com/conorheffron/redis-tester/security/code-scanning/2)

To fix this issue, explicitly set the `permissions` key at the root of the workflow file (above `jobs:`) or at the job level (inside the `build:` job), assigning the least privileges required. For most Java CI workflows, `contents: read` suffices, but in this workflow, the dependency submission (with `advanced-security/maven-dependency-submission-action`) requires `contents: write` and `security-events: write`, per [official docs](https://github.com/advanced-security/maven-dependency-submission-action). Add the following to the workflow root, just after `name: Java CI with Maven`, or inside the `build:` job:

```yaml
permissions:
  contents: read
  security-events: write
```

This limits the default token and enables just enough privileges for dependency submission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
